### PR TITLE
Demonstrate errors decoding Command in FlightSQL

### DIFF
--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -389,7 +389,7 @@ where
 
         let command = Command::try_from(msg.clone()).map_err(arrow_error_to_status)?;
         match command {
-            Command::TicketStatemetQuery(command) => {
+            Command::TicketStatementQuery(command) => {
                 return self.do_get_statement(command, request).await;
             }
             _ => {}

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -387,9 +387,14 @@ where
                 .ok_or_else(|| Status::internal("Expected a command, but found none."))
         }
 
-        if msg.is::<TicketStatementQuery>() {
-            return self.do_get_statement(unpack(msg)?, request).await;
-        }
+        let command = Command::try_from(msg.clone()).map_err(arrow_error_to_status)?;
+        match command {
+            Command::TicketStatemetQuery(command) => {
+                return self.do_get_statement(command, request).await;
+            }
+            _ => {}
+        };
+
         if msg.is::<CommandPreparedStatementQuery>() {
             return self.do_get_prepared_statement(unpack(msg)?, request).await;
         }


### PR DESCRIPTION
This PR shows a problem with trying to use `Command` introduced  in https://github.com/apache/arrow-rs/pull/3887

Specifically, the example test fails

```
     Running tests/flight_sql_client_cli.rs (/Users/alamb/Software/target-df/debug/deps/flight_sql_client_cli-0a6d454ad1fd696f)

running 1 test
test test_simple ... FAILED(B
```

```
command=`RUST_BACKTRACE="1" RUST_LOG="warn" "/Users/alamb/Software/target-df/debug/flight_sql_client" "--host" "127.0.0.1" "--port" "58931" "SELECT * FROM table;"`
code=101
stdout=""
stderr=```
thread \'main\' panicked at \'do get: IoError(\"Status { code: Internal, message: \\\"ParseError(\\\\\\\"Unable to decode Any value: type.googleapis.com/arrow.flight.protocol.sql.FetchResults\\\\\\\")\\\", metadata: MetadataMap { headers: {\\\"content-type\\\": \\\"application/grpc\\\", \\\"date\\\": \\\"Tue, 21 Mar 2023 15:20:27 GMT\\\", \\\"content-length\\\": \\\"0\\\"} }, source: None }\")\', arrow-flight/src/bin/flight_sql_client.rs:123:63
stack backtrace:
```

I believe the root cause is that some message other than a FlightSQL message is sent to the Flight service (which IOx does as well) and the decoding into `Command` fails

What do you think about making the conversion  to `Command` infallible (aka no error) with something like

```rust
enum Command {
...
  /// The protobuf was something other than  a FlightSQL message 
  Unknown(Any)
}
```

That way servers could handle all the FlightSQL messages as well as add custom decode logic if they wanted 🤔 

If you think this approach would be reasonable @stuartcarnie , I can give it a try